### PR TITLE
Fix the problem of Tag selector &quot;=&quot; filter can not match the whole word

### DIFF
--- a/server/metrics/storage-ext-es/src/main/java/com/alipay/sofa/lookout/server/storage/ext/es/QueryBuilder.java
+++ b/server/metrics/storage-ext-es/src/main/java/com/alipay/sofa/lookout/server/storage/ext/es/QueryBuilder.java
@@ -111,7 +111,7 @@ class QueryBuilder {
         }
 
         public StringQuery addTagCond(String tagKey, String tagValExpr) {
-            String expr = "tags:" + tagKey + "=" + tagValExpr;
+            String expr = "tags.keyword:" + tagKey + "=" + tagValExpr;
             valueExprs.add(expr);
             return this;
         }

--- a/server/metrics/storage-ext-es/src/test/java/com/alipay/sofa/lookout/server/storage/ext/es/QueryBuilderTest.java
+++ b/server/metrics/storage-ext-es/src/test/java/com/alipay/sofa/lookout/server/storage/ext/es/QueryBuilderTest.java
@@ -38,7 +38,7 @@ public class QueryBuilderTest {
         System.out.println(qry);
         Assert
             .assertEquals(
-                "{\"size\":10000,\"query\":{\"bool\":{\"must\":[{\"query_string\":{\"query\":\"tags:zone=G*\"}},{\"regexp\":{\"tags\":\"tags=.*ms\"}},{\"range\":{\"time\":{\"gte\":1556525226597,\"lte\":1556525226597,\"format\":\"epoch_millis\"}}}],\"must_not\":[{\"query_string\":{\"query\":\"tags:zone=G*\"}},{\"regexp\":{\"tags\":\"tags=.*ms\"}}]}}}",
+                "{\"size\":10000,\"query\":{\"bool\":{\"must\":[{\"query_string\":{\"query\":\"tags.keyword:zone=G*\"}},{\"regexp\":{\"tags\":\"tags=.*ms\"}},{\"range\":{\"time\":{\"gte\":1556525226597,\"lte\":1556525226597,\"format\":\"epoch_millis\"}}}],\"must_not\":[{\"query_string\":{\"query\":\"tags.keyword:zone=G*\"}},{\"regexp\":{\"tags\":\"tags=.*ms\"}}]}}}",
                 qry);
     }
 
@@ -52,7 +52,7 @@ public class QueryBuilderTest {
         System.out.println(qry);
         Assert
             .assertEquals(
-                "{\"size\":10000,\"query\":{\"bool\":{\"must\":[{\"query_string\":{\"query\":\"tags:zone=G*\"}},{\"regexp\":{\"tags\":\"tags=.*ms\"}},{\"range\":{\"time\":{\"gte\":1556525491882,\"lte\":1556525491882,\"format\":\"epoch_millis\"}}}],\"must_not\":[]}}}",
+                "{\"size\":10000,\"query\":{\"bool\":{\"must\":[{\"query_string\":{\"query\":\"tags.keyword:zone=G*\"}},{\"regexp\":{\"tags\":\"tags=.*ms\"}},{\"range\":{\"time\":{\"gte\":1556525491882,\"lte\":1556525491882,\"format\":\"epoch_millis\"}}}],\"must_not\":[]}}}",
                 qry);
     }
 
@@ -69,7 +69,7 @@ public class QueryBuilderTest {
         QueryBuilder.StringQuery stringQuery = new QueryBuilder.StringQuery();
         stringQuery.addTagCond("zone", "G*").addTagCond("app", "zk");
         System.out.println(stringQuery);
-        Assert.assertEquals("{\"query_string\":{\"query\":\"tags:zone=G* AND tags:app=zk\"}}",
+        Assert.assertEquals("{\"query_string\":{\"query\":\"tags.keyword:zone=G* AND tags.keyword:app=zk\"}}",
             stringQuery.toString());
 
         stringQuery = new QueryBuilder.StringQuery();


### PR DESCRIPTION
### Motivation:

Tag选择器的“=”筛选，不能实现全字匹配。
比如jvm.threads.daemon{app="foo"}，这样查询
实际结果是，能够查询到foo和gateway等多个应用的时序数据
预期结果是，只查询到foo应用的时序数据

### Modification:

使用ES的keyword特性，阻止ES进行分词

### Result:

Fixes #83 . 


